### PR TITLE
Added missing code to register the toolbar button before it is created

### DIFF
--- a/UbioWeldingLtd/EditorToolbar.cs
+++ b/UbioWeldingLtd/EditorToolbar.cs
@@ -5,9 +5,12 @@ using ToolbarControl_NS;
 
 namespace UbioWeldingLtd
 {
+	
 	public class EditorToolbar
 	{
-		private ToolbarControl _toolbarControl;
+        internal static string MODID = "UbioWeldingLtd";
+
+        private ToolbarControl _toolbarControl;
 		private readonly MonoBehaviour owner;
 
 		public EditorToolbar(MonoBehaviour owner) {
@@ -17,7 +20,7 @@ namespace UbioWeldingLtd
 			this._toolbarControl.AddToAllToolbars(
 				OnClickToolbarButton, null,
 				ApplicationLauncher.AppScenes.VAB | ApplicationLauncher.AppScenes.SPH,
-				"UbioWeldingLtd",
+				MODID,
 				"UbioWeldingLtdButton",
 				Constants.settingLargeIconGetPath,
 				Constants.settingSmallIconGetPath,

--- a/UbioWeldingLtd/RegisterToolbar.cs
+++ b/UbioWeldingLtd/RegisterToolbar.cs
@@ -1,0 +1,15 @@
+using ToolbarControl_NS;
+using UnityEngine;
+
+namespace UbioWeldingLtd
+{
+    [KSPAddon(KSPAddon.Startup.MainMenu, true)]
+    public class RegisterToolbar : MonoBehaviour
+    {
+
+        void Start()
+        {
+            ToolbarControl.RegisterMod(EditorToolbar.MODID, Constants.weldManufacturer);          
+        }
+    }
+}


### PR DESCRIPTION
The newer toolbar controller requires that the button be registered before it is used.  I've added one file and modified one other to support this.

Tested and working in a 1.4.5 install.
